### PR TITLE
feat: export all typings from the package

### DIFF
--- a/.changeset/giant-loops-divide.md
+++ b/.changeset/giant-loops-divide.md
@@ -1,0 +1,5 @@
+---
+"@workleap/mixpanel": patch
+---
+
+Export types from the packages

--- a/packages/mixpanel/src/createTrackingFunction.ts
+++ b/packages/mixpanel/src/createTrackingFunction.ts
@@ -27,7 +27,7 @@ function resolveApiUrl(path: string, baseUrl: string | undefined) : string {
     return `${baseUrl}${baseUrl!.endsWith("/") ? "" : "/"}${path.startsWith("/") ? path.substring(1) : path}`;
 }
 
-interface CreateTrackingFunctionOptions {
+export interface CreateTrackingFunctionOptions {
     /**
      * The product identifier of the target product.
      * @default null

--- a/packages/mixpanel/src/index.ts
+++ b/packages/mixpanel/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./createTrackingFunction.ts";
+export type { TrackEventProperties } from "./properties.ts";
 


### PR DESCRIPTION
This pull request focuses on exporting all typings from the package to improve the package's public API. Key changes include the addition of a changeset for versioning, exporting the TrackEventProperties type in the main index file, and making the CreateTrackingFunctionOptions interface public.