### PR TITLE
chore: update Retype GitHub Action

### DIFF
--- a/.github/workflows/retype-action.yml
+++ b/.github/workflows/retype-action.yml
@@ -1,6 +1,6 @@
 name: Publish documentation website to GitHub Pages
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
   push:
     branches: ["main"]
 
@@ -16,13 +16,9 @@ jobs:
     steps:
         - uses: actions/checkout@v4
 
-        - uses: actions/setup-dotnet@v1
-          with:
-            dotnet-version: 9.0.x
-
         - uses: retypeapp/action-build@latest
-          with:
-            license: ${{ secrets.RETYPE_API_KEY }}
+          env:
+              RETYPE_KEY: ${{ secrets.RETYPE_API_KEY }}
 
         - uses: retypeapp/action-github-pages@latest
           with:


### PR DESCRIPTION
## Summary
- Remove `actions/setup-dotnet` step (no longer needed)
- Switch from `with: license` to `env: RETYPE_KEY` for providing the Retype API key

Reference: https://retype.com/guides/github-actions/